### PR TITLE
Added back all tests and fixed the compilation errors on the new version of IPF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,13 @@
 			<version>${camel-version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.openehealth.ipf.commons</groupId>
+			<artifactId>ipf-commons-ihe-xds</artifactId>
+			<version>${ipf-version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
 
 	</dependencies>
 

--- a/src/test/java/ch/bfh/ti/i4mi/mag/TestBase.java
+++ b/src/test/java/ch/bfh/ti/i4mi/mag/TestBase.java
@@ -1,0 +1,46 @@
+package ch.bfh.ti.i4mi.mag;
+
+import ch.bfh.ti.i4mi.mag.MobileAccessGateway;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.CamelContext;
+import org.apache.camel.ProducerTemplate;
+import org.junit.jupiter.api.BeforeAll;
+import org.openehealth.ipf.commons.ihe.xacml20.Xacml20Utils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Locale;
+
+/**
+ * @author Dmytro Rud
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@Import(MobileAccessGateway.class)
+@ActiveProfiles("test")
+@Slf4j
+abstract public class TestBase {
+
+    @Autowired
+    protected CamelContext camelContext;
+
+    @Autowired
+    protected ProducerTemplate producerTemplate;
+
+    @Value("${server.port}")
+    protected Integer serverPort;
+
+    @BeforeAll
+    public static void beforeAll() {
+        Xacml20Utils.initializeHerasaf();
+        Locale.setDefault(Locale.ENGLISH);
+
+//        System.setProperty("javax.net.ssl.keyStore", "src/main/resources/example-server-certificate.p12");
+//        System.setProperty("javax.net.ssl.keyStorePassword", "a1b2c3");
+//        System.setProperty("javax.net.ssl.trustStore", "src/main/resources/example-server-certificate.p12");
+//        System.setProperty("javax.net.ssl.trustStorePassword", "a1b2c3");
+    }
+
+}

--- a/src/test/java/ch/bfh/ti/i4mi/mag/mhd/iti65/Iti65RouteBuilderTest.java
+++ b/src/test/java/ch/bfh/ti/i4mi/mag/mhd/iti65/Iti65RouteBuilderTest.java
@@ -1,0 +1,4 @@
+package ch.bfh.ti.i4mi.mag.mhd.iti65;
+
+public class Iti65RouteBuilderTest {
+}

--- a/src/test/java/ch/bfh/ti/i4mi/mag/mhd/iti66/IdRequestConverterTest.java
+++ b/src/test/java/ch/bfh/ti/i4mi/mag/mhd/iti66/IdRequestConverterTest.java
@@ -1,0 +1,47 @@
+package ch.bfh.ti.i4mi.mag.mhd.iti66;
+
+import ch.bfh.ti.i4mi.mag.TestBase;
+import org.junit.jupiter.api.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.QueryRegistry;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.GetSubmissionSetAndContentsQuery;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryRegistryTransformer;
+import org.openehealth.ipf.commons.ihe.xds.core.validate.requests.AdhocQueryRequestValidator;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openehealth.ipf.commons.ihe.xds.XDS.Interactions.ITI_18;
+
+public class IdRequestConverterTest extends TestBase {
+
+    private final IdRequestConverter _sut;
+    private final QueryRegistryTransformer _queryRegistryTransformer;
+
+    public IdRequestConverterTest() {
+        _sut = new IdRequestConverter();
+        _queryRegistryTransformer = new QueryRegistryTransformer();
+    }
+
+    @Test
+    public void idToGetDocumentQuery_MissingFhirHeader_null() {
+        QueryRegistry result = _sut.idToGetDocumentsQuery("");
+        assertNull(result);
+    }
+
+    @Test
+    public void idToGetDocumentQuery_NotContainingSlash_null() {
+        QueryRegistry result = _sut.idToGetDocumentsQuery("some-fhir-uri");
+        assertNull(result);
+    }
+
+    @Test
+    public void idToGetDocumentQuery_ValidFhirHttpUri_QueryValidated() {
+        QueryRegistry result = _sut.idToGetDocumentsQuery("some-fhir-uri/12345");
+
+        var uuid = ((GetSubmissionSetAndContentsQuery) result.getQuery()).getUuid();
+
+        assertTrue(result.getQuery() instanceof GetSubmissionSetAndContentsQuery);
+        assertEquals("12345", uuid);
+
+        var ebXmlResult = _queryRegistryTransformer.toEbXML(result);
+        AdhocQueryRequestValidator.getInstance().validate(ebXmlResult, ITI_18);
+    }
+}

--- a/src/test/java/ch/bfh/ti/i4mi/mag/mhd/iti66/Iti66RequestConverterTest.java
+++ b/src/test/java/ch/bfh/ti/i4mi/mag/mhd/iti66/Iti66RequestConverterTest.java
@@ -1,0 +1,156 @@
+package ch.bfh.ti.i4mi.mag.mhd.iti66;
+
+import ca.uhn.fhir.rest.param.*;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ch.bfh.ti.i4mi.mag.TestBase;
+import org.junit.jupiter.api.Test;
+import org.openehealth.ipf.commons.ihe.fhir.iti66_v401.Iti66SearchParameters;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.QueryRegistry;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryRegistryTransformer;
+import org.openehealth.ipf.commons.ihe.xds.core.validate.XDSMetaDataException;
+import org.openehealth.ipf.commons.ihe.xds.core.validate.requests.AdhocQueryRequestValidator;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.sql.Date;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openehealth.ipf.commons.ihe.xds.XDS.Interactions.ITI_18;
+
+public class Iti66RequestConverterTest extends TestBase {
+
+    @Autowired
+    private Iti66RequestConverter _sut;
+    private final QueryRegistryTransformer _queryRegistryTransformer;
+
+    public Iti66RequestConverterTest() {
+        _queryRegistryTransformer = new QueryRegistryTransformer();
+    }
+
+    @Test
+    public void searchParameterIti66ToFindSubmissionSetsQuery_ValidId_QueryValidated() {
+
+        var iti66SearchParametersQuery = Iti66SearchParameters.builder()
+                ._id(new TokenParam().setValue(UUID.randomUUID().toString()))
+                .build();
+
+        QueryRegistry queryRegistry = _sut.searchParameterIti66ToFindSubmissionSetsQuery(iti66SearchParametersQuery);
+
+        var ebXmlResult = _queryRegistryTransformer.toEbXML(queryRegistry);
+        AdhocQueryRequestValidator.getInstance().validate(ebXmlResult, ITI_18);
+    }
+
+    @Test
+    public void searchParameterIti66ToFindSubmissionSetsQuery_ValidIdentifierWithUUIDPrefix_QueryValidated() {
+
+        var iti66SearchParametersQuery = Iti66SearchParameters.builder()
+                .identifier(new TokenParam().setValue("urn:uuid:" + UUID.randomUUID()))
+                .build();
+
+        QueryRegistry queryRegistry = _sut.searchParameterIti66ToFindSubmissionSetsQuery(iti66SearchParametersQuery);
+
+        var ebXmlResult = _queryRegistryTransformer.toEbXML(queryRegistry);
+        AdhocQueryRequestValidator.getInstance().validate(ebXmlResult, ITI_18);
+    }
+
+    @Test
+    public void searchParameterIti66ToFindSubmissionSetsQuery_ValidIdentifierOIDPrefix_QueryValidated() {
+
+        var iti66SearchParametersQuery = Iti66SearchParameters.builder()
+                .identifier(new TokenParam().setValue("urn:oid:" + UUID.randomUUID()))
+                .build();
+
+        QueryRegistry queryRegistry = _sut.searchParameterIti66ToFindSubmissionSetsQuery(iti66SearchParametersQuery);
+
+        var ebXmlResult = _queryRegistryTransformer.toEbXML(queryRegistry);
+        AdhocQueryRequestValidator.getInstance().validate(ebXmlResult, ITI_18);
+    }
+
+    @Test
+    public void searchParameterIti66ToFindSubmissionSetsQuery_ValidIdentifierNoPrefix_QueryNotValidated() {
+
+        var iti66SearchParametersQuery = Iti66SearchParameters.builder()
+                .identifier(new TokenParam().setValue("some-invalid-prefix:" + UUID.randomUUID()))
+                .build();
+
+        QueryRegistry queryRegistry = _sut.searchParameterIti66ToFindSubmissionSetsQuery(iti66SearchParametersQuery);
+
+
+        String exceptionMessage = "";
+        try {
+            var ebXmlResult = _queryRegistryTransformer.toEbXML(queryRegistry);
+            AdhocQueryRequestValidator.getInstance().validate(ebXmlResult, ITI_18);
+        } catch (XDSMetaDataException e) {
+            exceptionMessage = e.getMessage();
+        }
+        assertTrue(exceptionMessage.contains("Missing required query parameter"));
+    }
+
+    @Test
+    public void searchParameterIti66ToFindSubmissionSetsQuery_SimpleQuery_QueryValidated() {
+
+        var iti66SearchParametersQuery = Iti66SearchParameters.builder()
+                .code(new TokenParam().setValue("submissionset"))
+                .patientIdentifier(new TokenParam().setSystem("urn:oid:1.2.3.4.5").setValue("some-value"))
+                .status(new TokenOrListParam().add("current"))
+                .build();
+
+        QueryRegistry queryRegistry = _sut.searchParameterIti66ToFindSubmissionSetsQuery(iti66SearchParametersQuery);
+
+        var ebXmlResult = _queryRegistryTransformer.toEbXML(queryRegistry);
+        AdhocQueryRequestValidator.getInstance().validate(ebXmlResult, ITI_18);
+    }
+
+    @Test
+    public void searchParameterIti66ToFindSubmissionSetsQuery_InvalidCode_ThrowsInvalidRequestException() {
+        var iti66SearchParametersQuery = Iti66SearchParameters.builder()
+                .code(new TokenParam().setValue("some-random-value"))
+                .build();
+
+        checkException(iti66SearchParametersQuery, "Only search for submissionsets supported.");
+    }
+
+    @Test
+    public void searchParameterIti66ToFindSubmissionSetsQuery_InvalidPatientIdentifier_ThrowsInvalidRequestException() {
+        var iti66SearchParametersQuery = Iti66SearchParameters.builder()
+                .code(new TokenParam().setValue("submissionset"))
+                .patientIdentifier(new TokenParam().setValue("some-value"))
+                .build();
+
+        checkException(iti66SearchParametersQuery, "Missing OID for patient");
+    }
+
+    @Test
+    public void searchParameterIti66ToFindSubmissionSetsQuery_FullQuery_QueryValidated() {
+
+        var iti66SearchParametersQuery = Iti66SearchParameters.builder()
+                .code(new TokenParam().setValue("submissionset"))
+                .date(new DateRangeParam(new DateParam("2023-01-01"), new DateParam("2023-12-31")))
+                .sourceFamily(new StringParam("some-family"))
+                .sourceGiven(new StringParam("some-given"))
+                .designationType(new TokenOrListParam().add("2.16.840.1.113883.6.96", "some-value"))
+                .sourceId(new TokenOrListParam().add("some-value"))
+                .status(new TokenOrListParam().add("current"))
+                //.patientIdentifier(new TokenParam().setSystem("urn:oid:1.2.3.4.5").setValue("some-value"))
+                .patientReference(new ReferenceParam().setValue("Patient?identifier=urn:oid:1.2.3.4.5.6|some-value"))
+                .build();
+
+        QueryRegistry queryRegistry = _sut.searchParameterIti66ToFindSubmissionSetsQuery(iti66SearchParametersQuery);
+
+        var ebXmlResult = _queryRegistryTransformer.toEbXML(queryRegistry);
+        AdhocQueryRequestValidator.getInstance().validate(ebXmlResult, ITI_18);
+    }
+
+
+    private void checkException(Iti66SearchParameters params, String expectedMessage) {
+        var exceptionMessage = "";
+        try {
+            QueryRegistry queryRegistry = _sut.searchParameterIti66ToFindSubmissionSetsQuery(params);
+        }
+        catch (InvalidRequestException ex){
+            exceptionMessage = ex.getMessage();
+        }
+
+        assertTrue(exceptionMessage.contains(expectedMessage));
+    }
+}

--- a/src/test/java/ch/bfh/ti/i4mi/mag/mhd/iti66/Iti66ResponseBugfixTest.java
+++ b/src/test/java/ch/bfh/ti/i4mi/mag/mhd/iti66/Iti66ResponseBugfixTest.java
@@ -1,0 +1,89 @@
+package ch.bfh.ti.i4mi.mag.mhd.iti66;
+
+import ch.bfh.ti.i4mi.mag.TestBase;
+import org.junit.jupiter.api.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.SampleData;
+import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.query.AdhocQueryResponse;
+import org.openehealth.ipf.commons.ihe.xds.core.stub.ebrs30.rim.*;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.QName;
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class Iti66ResponseBugfixTest extends TestBase {
+
+    private final Iti66ResponseBugfix _sut;
+    private final ObjectFactory objectFactory;
+
+    public Iti66ResponseBugfixTest() {
+
+        _sut = new Iti66ResponseBugfix();
+        objectFactory = new ObjectFactory();
+    }
+
+    @Test
+    public void fixResponse_MissingClassificationType_AddNewClassificationTypeToInput() {
+
+        var registryObjectList = new RegistryObjectListType();
+
+        var toBeFixedInput = new AdhocQueryResponse();
+
+        toBeFixedInput.setStartIndex(BigInteger.valueOf(1));
+        toBeFixedInput.setRegistryObjectList(registryObjectList);
+        toBeFixedInput.setTotalResultCount(BigInteger.valueOf(1));
+
+        var adhocQueryResponse = _sut.fixResponse(toBeFixedInput);
+
+        var registryPackages = adhocQueryResponse.getRegistryObjectList().getIdentifiable();
+
+        assertionForRegistryPackages(registryPackages);
+    }
+
+    @Test
+    public void fixResponse_ExistingClassificationType_InputIsReturnedUnmodified() {
+
+        var registryObjectList = new RegistryObjectListType();
+        var registryPackagesIdentifiables = registryObjectList.getIdentifiable();
+
+        var registryPackageType = new RegistryPackageType();
+        var newClassificationType = new ClassificationType();
+        newClassificationType.setClassificationNode("urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd");
+        newClassificationType.setClassifiedObject(registryPackageType.getId());
+        registryPackageType.getClassification().add(newClassificationType);
+
+        registryPackagesIdentifiables.add(objectFactory.createClassification(newClassificationType));
+
+        var toBeFixedInput = new AdhocQueryResponse();
+
+        toBeFixedInput.setStartIndex(BigInteger.valueOf(1));
+        toBeFixedInput.setRegistryObjectList(registryObjectList);
+        toBeFixedInput.setTotalResultCount(BigInteger.valueOf(1));
+
+        var result = _sut.fixResponse(toBeFixedInput);
+        var registryPackages = result.getRegistryObjectList().getIdentifiable();
+
+        assertionForRegistryPackages(registryPackages);
+    }
+
+    private static void assertionForRegistryPackages(List<JAXBElement<? extends IdentifiableType>> registryPackages) {
+
+        ClassificationType neededClassificationType = new ClassificationType();
+        neededClassificationType.setClassificationNode("urn:uuid:a54d6aa5-d40d-43f9-88c5-b4633d873bdd");
+
+        registryPackages.stream().forEach(possibleRegistryPackage -> {
+            var type = possibleRegistryPackage.getValue();
+            if(type instanceof RegistryPackageType){
+
+                RegistryPackageType registryPackageType = (RegistryPackageType) type;
+
+                neededClassificationType.setClassifiedObject(registryPackageType.getId());
+
+                var classifications = registryPackageType.getClassification();
+
+                assertEquals(1, classifications.stream().filter(classification -> classification.equals(neededClassificationType)).count());
+        }});
+    }
+}

--- a/src/test/java/ch/bfh/ti/i4mi/mag/mhd/iti66/Iti66ResponseConverterTest.java
+++ b/src/test/java/ch/bfh/ti/i4mi/mag/mhd/iti66/Iti66ResponseConverterTest.java
@@ -1,0 +1,34 @@
+package ch.bfh.ti.i4mi.mag.mhd.iti66;
+
+import ch.bfh.ti.i4mi.mag.Config;
+import ch.bfh.ti.i4mi.mag.TestBase;
+import org.junit.jupiter.api.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.SampleData;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.AssigningAuthority;
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.Identifiable;
+import org.openehealth.ipf.commons.ihe.xds.core.responses.QueryResponse;
+import org.openehealth.ipf.commons.ihe.xds.core.responses.Status;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class Iti66ResponseConverterTest extends TestBase {
+
+    private final Iti66ResponseConverter _sut;
+
+    @Autowired
+    public Iti66ResponseConverterTest(Config config) {
+        _sut = new Iti66ResponseConverter(config);
+    }
+
+    @Test
+    public void translateToFhir_ValidInput_ValidTranslation() {
+
+        var queryResponse = SampleData.createQueryResponseWithLeafClass(Status.SUCCESS, new Identifiable("some-id", new AssigningAuthority("1.2.3.4.5")));
+
+        var fhirStuff = _sut.translateToFhir(queryResponse, null);
+
+        // TODO verify translation -> Dmytro
+
+
+
+    }
+}

--- a/src/test/java/ch/bfh/ti/i4mi/mag/mhd/iti67/IdRequestConverterTest.java
+++ b/src/test/java/ch/bfh/ti/i4mi/mag/mhd/iti67/IdRequestConverterTest.java
@@ -1,0 +1,45 @@
+package ch.bfh.ti.i4mi.mag.mhd.iti67;
+import ch.bfh.ti.i4mi.mag.TestBase;
+import org.junit.jupiter.api.Test;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.QueryRegistry;
+import org.openehealth.ipf.commons.ihe.xds.core.requests.query.GetDocumentsQuery;
+import org.openehealth.ipf.commons.ihe.xds.core.transform.requests.QueryRegistryTransformer;
+import org.openehealth.ipf.commons.ihe.xds.core.validate.requests.AdhocQueryRequestValidator;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openehealth.ipf.commons.ihe.xds.XDS.Interactions.ITI_18;
+
+public class IdRequestConverterTest extends TestBase{
+    private final IdRequestConverter _sut;
+    private final QueryRegistryTransformer _queryRegistryTransformer;
+
+    public IdRequestConverterTest() {
+        _sut = new IdRequestConverter();
+        _queryRegistryTransformer = new QueryRegistryTransformer();
+    }
+
+    @Test
+    public void idToGetDocumentQuery_MissingFhirHeader_null() {
+        QueryRegistry result = _sut.idToGetDocumentsQuery("");
+        assertNull(result);
+    }
+
+    @Test
+    public void idToGetDocumentQuery_NotContainingSlash_null() {
+        QueryRegistry result = _sut.idToGetDocumentsQuery("some-fhir-uri");
+        assertNull(result);
+    }
+
+    @Test
+    public void idToGetDocumentQuery_ValidFhirHttpUri_QueryValidated() {
+        QueryRegistry result = _sut.idToGetDocumentsQuery("some-fhir-uri/12345");
+
+        var uuid = ((GetDocumentsQuery) result.getQuery()).getUuids().get(0);
+        assertTrue(result.getQuery() instanceof GetDocumentsQuery);
+        assertEquals("urn:uuid:12345", uuid);
+
+        var ebXmlResult = _queryRegistryTransformer.toEbXML(result);
+        AdhocQueryRequestValidator.getInstance().validate(ebXmlResult, ITI_18);
+    }
+
+}


### PR DESCRIPTION
I brought back again, the tests on ITI65,66 and 67 to the level that they had before the upgrade of IPF.

I did the needed changed in the code to fix the compilation errors and I added the missing test references to the pom file.

This brings the tests to a level where they are compliant with version 4.8.0 of IPF and are potentially ready to be integrated into the main project.
