### PR TITLE
chore: enable the actuator endpoints to answer the requirements of ha…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,12 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
 		<!-- <dependency>
 		  <groupId>org.apache.camel.springboot</groupId>
 		  <artifactId>camel-rest-starter</artifactId>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -104,3 +104,18 @@ camel:
 spring:
   application:
     name: mobile-access-gateway
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+    shutdown:
+      enabled: true
+    info:
+      enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+        exclude: "env,beans"


### PR DESCRIPTION
This PR, enables the Readiness and Liveness Probes that are needed for Kubernetes deployments, but not only for that.
In fact one can also rely on the features of Actuator if the application is deployed in a VM and put behind a Load Balancer, where the traffic is sent or not, based on the response from the HealthCheck.

When we test this, we can start with the **/actuator/health** endpoint, the result is below:

![image](https://github.com/swisspost/MobileAccessGateway/assets/8686515/75eeca76-ccdb-4886-97ea-19fab761b756)

Testing in detail the two mentioned endpoints, **/actuator/health/liveness** and **/actuator/health/readiness** give the results below:

![image](https://github.com/swisspost/MobileAccessGateway/assets/8686515/8d61bc2b-517b-447d-8461-d45e2ad4022b)

and

![image](https://github.com/swisspost/MobileAccessGateway/assets/8686515/9165a608-9327-420e-a6e2-cde12052eb45)

We advise to read the following section specific to Kubernetes.
https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html?query=health%27%20target=_blank%3E%3Cb%3Ehealth%3C/b%3E%3C/a%3E-groups#actuator.endpoints.kubernetes-probes